### PR TITLE
Fixed the way tiles rotate and change orientation

### DIFF
--- a/src/Tile.java
+++ b/src/Tile.java
@@ -24,35 +24,30 @@ public class Tile {
     }
 
     public void clockwiseRotation() {
-        //swap L and M hexagons
+        //L->R, R->M, M->L
         if(tileOrientation == TileOrientation.TOPHEAVY) {
-            Hexagon toBeMiddleHex = leftHex;
+            Hexagon swapHex = leftHex;
             leftHex = middleHex;
-            middleHex = toBeMiddleHex;
-            tileOrientation = TileOrientation.BOTTOMHEAVY;
+            middleHex = rightHex;
+            rightHex = swapHex;
         }
-        //swap swap M and R hexagons
+        //L->M, M->R, R->L
         else if(tileOrientation == TileOrientation.BOTTOMHEAVY) {
-            Hexagon toBeMiddleHex = rightHex;
+            Hexagon swapHex = leftHex;
+            leftHex = rightHex;
             rightHex = middleHex;
-            middleHex = toBeMiddleHex;
-            tileOrientation = TileOrientation.TOPHEAVY;
+            middleHex = swapHex;
         }
     }
 
-    public void counterClockwiseRotation() {
+    public void changeOrientation() {
         //swap M and R hexagons
+        Hexagon swapHex = rightHex;
+        rightHex = middleHex;
+        middleHex = swapHex;
         if(tileOrientation == TileOrientation.TOPHEAVY) {
-            Hexagon toBeMiddleHex = rightHex;
-            rightHex = middleHex;
-            middleHex = toBeMiddleHex;
             tileOrientation = TileOrientation.BOTTOMHEAVY;
-        }
-        //swap L and M hexagons
-        else if(tileOrientation == TileOrientation.BOTTOMHEAVY) {
-            Hexagon toBeMiddleHex = leftHex;
-            leftHex = middleHex;
-            middleHex = toBeMiddleHex;
+        } else if (tileOrientation == TileOrientation.BOTTOMHEAVY) {
             tileOrientation = TileOrientation.TOPHEAVY;
         }
     }

--- a/test/TileTests.java
+++ b/test/TileTests.java
@@ -29,34 +29,34 @@ public class TileTests {
         tile.clockwiseRotation(); //topHeavy Tile rotating clockwise
 
         Assert.assertEquals(jungle, tile.getTerrainTypeForPosition(HexagonPosition.LEFT));
-        Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
-        Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
+        Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
+        Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
 
         tile.clockwiseRotation(); //bottomHeavy Tile rotating clockwise
 
-        Assert.assertEquals(jungle, tile.getTerrainTypeForPosition(HexagonPosition.LEFT));
-        Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
-        Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
+        Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.LEFT));
+        Assert.assertEquals(jungle, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
+        Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
     }
 
     @Test
-    public void testTileCounterClockwiseRotation() {
+    public void testTileChangeOrientation() {
         TerrainType volcano = TerrainType.VOLCANO;
         TerrainType grasslands = TerrainType.GRASSLANDS;
         TerrainType jungle = TerrainType.JUNGLE;
 
         Tile tile = new Tile(volcano, grasslands, jungle);
 
-        tile.counterClockwiseRotation(); //topHeavy Tile rotating counter-clockwise
+        tile.changeOrientation(); //topHeavy tile becomes bottomHeavy
 
         Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.LEFT));
         Assert.assertEquals(jungle, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
         Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
 
-        tile.counterClockwiseRotation(); //bottomHeavy Tile rotating counter-clockwise
+        tile.changeOrientation(); //bottomHeavy tile becomes topHeavy
 
-        Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.LEFT));
-        Assert.assertEquals(jungle, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
-        Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
+        Assert.assertEquals(volcano, tile.getTerrainTypeForPosition(HexagonPosition.LEFT));
+        Assert.assertEquals(grasslands, tile.getTerrainTypeForPosition(HexagonPosition.RIGHT));
+        Assert.assertEquals(jungle, tile.getTerrainTypeForPosition(HexagonPosition.MIDDLE));
     }
 }


### PR DESCRIPTION
Previously tiles when rotated also changed orientation, which they should not.

clockwiseRotation changes positions of terrains on a tile's hexagons
-topHeavy: L->R, R->M, M->L
-bottomHeavy: L->M, M->R, R->L

changeOrientation changes between top and bottom heavy
-Swaps Right and Middle terrains of the tile then changes to the other orientation

TileTests now reflect this change