### PR TITLE
Fixed founding on a level 2+ hex

### DIFF
--- a/src/Board.java
+++ b/src/Board.java
@@ -192,7 +192,7 @@ public class Board {
                 Point neighborPoint = boardPointForOffset(neighborOffset);
                 Hexagon neighborHex = hexagonAtPoint(neighborPoint);
 
-                if (!neighborHex.isOccupied() && neighborHex.getTerrainType() != TerrainType.VOLCANO && neighborHex.getTerrainType() != TerrainType.EMPTY && hex.getLevel() == 1) {
+                if (!neighborHex.isOccupied() && neighborHex.getTerrainType() != TerrainType.VOLCANO && neighborHex.getTerrainType() != TerrainType.EMPTY && neighborHex.getLevel() == 1) {
                     validOffsets.put(neighborOffset, true);
                     visited.put(neighborOffset, true);
                 } else if (neighborHex.getTerrainType() == TerrainType.EMPTY) {


### PR DESCRIPTION
Board was checking if hex was at level 1, not neighbor hex.  This is likely the cause of the issue where we tried to found on a level 2 or higher hex.